### PR TITLE
Transit GW: bug fix + make resolverRuleId optional

### DIFF
--- a/packages/@cosmos-building-blocks/transit-gateway/test/__snapshots__/tgw-connect.test.ts.snap
+++ b/packages/@cosmos-building-blocks/transit-gateway/test/__snapshots__/tgw-connect.test.ts.snap
@@ -13,6 +13,9 @@ Object {
       "Type": "AWS::Route53Resolver::ResolverRuleAssociation",
     },
     "MyTgwConnectionTGWRouteMainSubnet1D754DB0E": Object {
+      "DependsOn": Array [
+        "MyTgwConnectionTransitGatewayAttachmentBB73CC5E",
+      ],
       "Properties": Object {
         "DestinationCidrBlock": "10.0.0.0/8",
         "RouteTableId": Object {
@@ -23,6 +26,9 @@ Object {
       "Type": "AWS::EC2::Route",
     },
     "MyTgwConnectionTGWRouteRedisSubnet117AE6F3C": Object {
+      "DependsOn": Array [
+        "MyTgwConnectionTransitGatewayAttachmentBB73CC5E",
+      ],
       "Properties": Object {
         "DestinationCidrBlock": "10.0.0.0/8",
         "RouteTableId": Object {

--- a/packages/@cosmos-building-blocks/transit-gateway/test/tgw-connect.test.ts
+++ b/packages/@cosmos-building-blocks/transit-gateway/test/tgw-connect.test.ts
@@ -41,6 +41,36 @@ describe('Transit Gateway Connection', () => {
     expect(testStacksynth).toHaveResource('AWS::EC2::Route');
   });
 
+  test('should not create resolver rule association if prop not passed', () => {
+    const app1 = new App();
+    const testStack1 = new Stack(app1, 'TestStack1');
+    const myvpc = new Vpc(testStack1, 'TestVpc', {
+      cidr: '10.180.7.0/24',
+      maxAzs: 1,
+      subnetConfiguration: [
+        {
+          name: 'Main',
+          subnetType: SubnetType.ISOLATED,
+          cidrMask: 26,
+        },
+        {
+          name: 'Redis',
+          subnetType: SubnetType.ISOLATED,
+          cidrMask: 28,
+        },
+      ],
+    });
+    new TgwConnect(testStack1, 'MyTgwConnection1', {
+      vpc: myvpc,
+      transitGatewayId,
+      tgwDestinationCidr,
+    });
+    const testStack1synth = SynthUtils.synthesize(testStack1);
+    expect(testStack1synth).not.toHaveResource('AWS::Route53Resolver::ResolverRuleAssociation');
+    expect(testStack1synth).toHaveResource('AWS::EC2::TransitGatewayAttachment');
+    expect(testStack1synth).toHaveResource('AWS::EC2::Route');
+  });
+
   test('should match snapshot', () => {
     expect(testStacksynth.template).toMatchSnapshot();
   });


### PR DESCRIPTION
- Added dependency so route creation waits for Transit Gateway Attachment.
- Made `resolverRuleId` optional
- Added more tests