### PR TITLE
SolarSystem ALB healthchek keeps failing #51

### DIFF
--- a/packages/@cdk-cosmos/core/src/ecs-solar-system.ts
+++ b/packages/@cdk-cosmos/core/src/ecs-solar-system.ts
@@ -50,7 +50,7 @@ export class EcsSolarSystemStack extends SolarSystemStack implements EcsSolarSys
       maxCapacity: 5,
     });
 
-    const AlbSecurityGroup = new SecurityGroup(this, 'SecurityGroup', {
+    const AlbSecurityGroup = new SecurityGroup(this, 'AlbSecurityGroup', {
       vpc: this.Vpc,
       description: 'SecurityGroup for SolarSystem ALB',
       allowAllOutbound: true,

--- a/packages/@cdk-cosmos/core/src/ecs-solar-system.ts
+++ b/packages/@cdk-cosmos/core/src/ecs-solar-system.ts
@@ -1,5 +1,5 @@
 import { Construct, StackProps } from '@aws-cdk/core';
-import { InstanceType } from '@aws-cdk/aws-ec2';
+import { InstanceType, SecurityGroup } from '@aws-cdk/aws-ec2';
 import { Cluster, ICluster } from '@aws-cdk/aws-ecs';
 import {
   ApplicationLoadBalancer,
@@ -50,10 +50,18 @@ export class EcsSolarSystemStack extends SolarSystemStack implements EcsSolarSys
       maxCapacity: 5,
     });
 
+    const AlbSecurityGroup = new SecurityGroup(this, 'SecurityGroup', {
+      vpc: this.Vpc,
+      description: 'SecurityGroup for SolarSystem ALB',
+      allowAllOutbound: true,
+    });
+
     this.Alb = new ApplicationLoadBalancer(this, 'Alb', {
       vpc: this.Vpc,
       loadBalancerName: RESOLVE(PATTERN.SINGLETON_SOLAR_SYSTEM, 'Alb', this),
+      securityGroup: AlbSecurityGroup,
     });
+
     this.HttpListener = this.Alb.addListener('HttpListener', {
       protocol: ApplicationProtocol.HTTP,
       defaultTargetGroups: [

--- a/packages/@cdk-cosmos/core/test/__snapshots__/ecs-solar-system.test.ts.snap
+++ b/packages/@cdk-cosmos/core/test/__snapshots__/ecs-solar-system.test.ts.snap
@@ -19,7 +19,7 @@ Object {
       },
       "Value": Object {
         "Fn::GetAtt": Array [
-          "SecurityGroupDD263621",
+          "AlbSecurityGroup86A59E99",
           "GroupId",
         ],
       },
@@ -38,7 +38,7 @@ Object {
       },
       "Value": Object {
         "Fn::GetAtt": Array [
-          "SecurityGroupDD263621",
+          "AlbSecurityGroup86A59E99",
           "GroupId",
         ],
       },
@@ -107,7 +107,7 @@ Object {
         "SecurityGroups": Array [
           Object {
             "Fn::GetAtt": Array [
-              "SecurityGroupDD263621",
+              "AlbSecurityGroup86A59E99",
               "GroupId",
             ],
           },
@@ -141,6 +141,31 @@ Object {
         "Protocol": "HTTP",
       },
       "Type": "AWS::ElasticLoadBalancingV2::Listener",
+    },
+    "AlbSecurityGroup86A59E99": Object {
+      "Properties": Object {
+        "GroupDescription": "SecurityGroup for SolarSystem ALB",
+        "SecurityGroupEgress": Array [
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound traffic by default",
+            "IpProtocol": "-1",
+          },
+        ],
+        "SecurityGroupIngress": Array [
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow from anyone on port 80",
+            "FromPort": 80,
+            "IpProtocol": "tcp",
+            "ToPort": 80,
+          },
+        ],
+        "VpcId": Object {
+          "Fn::ImportValue": "Core-Test-Mgt-Galaxy:ExportsOutputRefSharedVpc96F0F6140AE947C7",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
     },
     "ClusterCapacityASGA6ED330E": Object {
       "Properties": Object {
@@ -677,31 +702,6 @@ echo ECS_AWSVPC_BLOCK_IMDS=true >> /etc/ecs/ecs.config",
         },
       },
       "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
-    },
-    "SecurityGroupDD263621": Object {
-      "Properties": Object {
-        "GroupDescription": "SecurityGroup for SolarSystem ALB",
-        "SecurityGroupEgress": Array [
-          Object {
-            "CidrIp": "0.0.0.0/0",
-            "Description": "Allow all outbound traffic by default",
-            "IpProtocol": "-1",
-          },
-        ],
-        "SecurityGroupIngress": Array [
-          Object {
-            "CidrIp": "0.0.0.0/0",
-            "Description": "Allow from anyone on port 80",
-            "FromPort": 80,
-            "IpProtocol": "tcp",
-            "ToPort": 80,
-          },
-        ],
-        "VpcId": Object {
-          "Fn::ImportValue": "Core-Test-Mgt-Galaxy:ExportsOutputRefSharedVpc96F0F6140AE947C7",
-        },
-      },
-      "Type": "AWS::EC2::SecurityGroup",
     },
     "ZoneA5DE4B68": Object {
       "Properties": Object {

--- a/packages/@cdk-cosmos/core/test/__snapshots__/ecs-solar-system.test.ts.snap
+++ b/packages/@cdk-cosmos/core/test/__snapshots__/ecs-solar-system.test.ts.snap
@@ -19,7 +19,7 @@ Object {
       },
       "Value": Object {
         "Fn::GetAtt": Array [
-          "AlbSecurityGroup580F65A6",
+          "SecurityGroupDD263621",
           "GroupId",
         ],
       },
@@ -38,7 +38,7 @@ Object {
       },
       "Value": Object {
         "Fn::GetAtt": Array [
-          "AlbSecurityGroup580F65A6",
+          "SecurityGroupDD263621",
           "GroupId",
         ],
       },
@@ -107,7 +107,7 @@ Object {
         "SecurityGroups": Array [
           Object {
             "Fn::GetAtt": Array [
-              "AlbSecurityGroup580F65A6",
+              "SecurityGroupDD263621",
               "GroupId",
             ],
           },
@@ -141,33 +141,6 @@ Object {
         "Protocol": "HTTP",
       },
       "Type": "AWS::ElasticLoadBalancingV2::Listener",
-    },
-    "AlbSecurityGroup580F65A6": Object {
-      "Properties": Object {
-        "GroupDescription": "Automatically created Security Group for ELB CoreTestMgtDevSolarSystemAlbD8433EC7",
-        "SecurityGroupEgress": Array [
-          Object {
-            "CidrIp": "255.255.255.255/32",
-            "Description": "Disallow all traffic",
-            "FromPort": 252,
-            "IpProtocol": "icmp",
-            "ToPort": 86,
-          },
-        ],
-        "SecurityGroupIngress": Array [
-          Object {
-            "CidrIp": "0.0.0.0/0",
-            "Description": "Allow from anyone on port 80",
-            "FromPort": 80,
-            "IpProtocol": "tcp",
-            "ToPort": 80,
-          },
-        ],
-        "VpcId": Object {
-          "Fn::ImportValue": "Core-Test-Mgt-Galaxy:ExportsOutputRefSharedVpc96F0F6140AE947C7",
-        },
-      },
-      "Type": "AWS::EC2::SecurityGroup",
     },
     "ClusterCapacityASGA6ED330E": Object {
       "Properties": Object {
@@ -704,6 +677,31 @@ echo ECS_AWSVPC_BLOCK_IMDS=true >> /etc/ecs/ecs.config",
         },
       },
       "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+    },
+    "SecurityGroupDD263621": Object {
+      "Properties": Object {
+        "GroupDescription": "SecurityGroup for SolarSystem ALB",
+        "SecurityGroupEgress": Array [
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound traffic by default",
+            "IpProtocol": "-1",
+          },
+        ],
+        "SecurityGroupIngress": Array [
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow from anyone on port 80",
+            "FromPort": 80,
+            "IpProtocol": "tcp",
+            "ToPort": 80,
+          },
+        ],
+        "VpcId": Object {
+          "Fn::ImportValue": "Core-Test-Mgt-Galaxy:ExportsOutputRefSharedVpc96F0F6140AE947C7",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
     },
     "ZoneA5DE4B68": Object {
       "Properties": Object {


### PR DESCRIPTION
bug fix for :
SolarSystem ALB healthcheck keeps failing #51 

- Can't change default SG which ALB creates
- so creating new security group(Allowing Egress) and using that while creating ALB