### PR TITLE
AlbDnsNameOutput fix for Alb Export Name in app-alb-nlb building block #58

### DIFF
--- a/packages/@cosmos-building-blocks/app-ec2/src/app-alb-nlb.ts
+++ b/packages/@cosmos-building-blocks/app-ec2/src/app-alb-nlb.ts
@@ -168,6 +168,11 @@ export class AppAlb extends Construct {
       exportName: `${props.envName}-InternalListener`,
     });
 
+    new CfnOutput(this, 'AlbDnsNameOutput', {
+      value: uiAlb.loadBalancerDnsName,
+      exportName: `${props.envName}-ALBDnsNameOutput`,
+    });
+
     this.internalListener = internalListener;
 
     this.albDnsAddress = uiAlb.loadBalancerDnsName;


### PR DESCRIPTION
AlbDnsNameOutput fix for Alb Export Name in app-alb-nlb building block #58